### PR TITLE
Add mobile header and responsive sidebar toggle

### DIFF
--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -73,3 +73,66 @@ h1 {
 .tw-sider .ant-menu {
   background: transparent;
 }
+
+.tw-mobile-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3.125rem;
+  background: #ffffff;
+  z-index: 999;
+  padding: 0.625rem 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.tw-mobile-header__toggle {
+  position: absolute;
+  left: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.25rem;
+  color: #1f1f1f;
+}
+
+.tw-mobile-header__logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tw-mobile-header__logo img {
+  height: 28px;
+  width: auto;
+}
+
+@media (min-width: 960px) {
+  .tw-mobile-header {
+    display: none;
+  }
+}
+
+@media (max-width: 959.98px) {
+  .tw-sider.tw-sider--mobile {
+    position: fixed !important;
+    top: 3.125rem;
+    left: 0;
+    bottom: 0;
+    width: 220px;
+    height: calc(100vh - 3.125rem);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 998;
+    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.15);
+    overflow-y: auto;
+    pointer-events: none;
+  }
+
+  .tw-sider.tw-sider--mobile.tw-sider--open {
+    transform: translateX(0);
+    pointer-events: auto;
+  }
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,13 +1,43 @@
+import { useEffect, useState } from 'react';
 import { Layout } from 'antd';
-import { Sidebar } from './Sidebar';
 import { Outlet } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+import { MobileHeader } from './MobileHeader';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+const MOBILE_BREAKPOINT = '(max-width: 959.98px)';
 
 export default function AppLayout() {
+  const isMobile = useMediaQuery(MOBILE_BREAKPOINT);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isMobile) {
+      setIsSidebarOpen(false);
+    }
+  }, [isMobile]);
+
   return (
     <Layout className="tw-layout" style={{ minHeight: '100vh' }}>
-      <Sidebar />
+      <Sidebar
+        isMobile={isMobile}
+        open={!isMobile || isSidebarOpen}
+        onClose={() => setIsSidebarOpen(false)}
+      />
       <Layout>
-        <Layout.Content style={{ padding: '24px', position: 'relative', zIndex: 1 }}>
+        {isMobile && (
+          <MobileHeader
+            isOpen={isSidebarOpen}
+            onToggle={() => setIsSidebarOpen((prev) => !prev)}
+          />
+        )}
+        <Layout.Content
+          style={{
+            padding: isMobile ? 'calc(3.125rem + 24px) 24px 24px' : '24px',
+            position: 'relative',
+            zIndex: 1,
+          }}
+        >
           <Outlet />
         </Layout.Content>
       </Layout>

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,0 +1,26 @@
+import { CloseOutlined, MenuOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
+import logo from '@/assets/images/logo.svg';
+
+type MobileHeaderProps = {
+  isOpen: boolean;
+  onToggle: () => void;
+};
+
+export function MobileHeader({ isOpen, onToggle }: MobileHeaderProps) {
+  return (
+    <header className="tw-mobile-header">
+      <Button
+        aria-label={isOpen ? 'Sulge külgriba' : 'Ava külgriba'}
+        aria-expanded={isOpen}
+        type="text"
+        onClick={onToggle}
+        icon={isOpen ? <CloseOutlined /> : <MenuOutlined />}
+        className="tw-mobile-header__toggle"
+      />
+      <div className="tw-mobile-header__logo">
+        <img src={logo} alt="Trinidad Wiseman" />
+      </div>
+    </header>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,66 +1,57 @@
-import {
-  MenuFoldOutlined,
-  MenuUnfoldOutlined,
-  FileTextOutlined,
-  TableOutlined,
-  QuestionCircleOutlined,
-} from '@ant-design/icons';
-import { Button, Menu, Grid } from 'antd';
+import { FileTextOutlined, QuestionCircleOutlined, TableOutlined } from '@ant-design/icons';
+import { Menu } from 'antd';
+import type { MenuProps } from 'antd';
 import Sider from 'antd/es/layout/Sider';
-import { useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import logo from '@/assets/images/logo.svg';
 
-const { useBreakpoint } = Grid;
+type SidebarProps = {
+  isMobile: boolean;
+  open: boolean;
+  onClose?: () => void;
+};
 
-export function Sidebar() {
-  const [collapsed, setCollapsed] = useState(false);
-  const screens = useBreakpoint();
-  const isMobile = !screens.lg; // < lg => mobile/tablet
+const menuItems: MenuProps['items'] = [
+  { key: '/', icon: <QuestionCircleOutlined />, label: 'Nõuded' },
+  { key: '/article', icon: <FileTextOutlined />, label: 'Artikkel' },
+  { key: '/table', icon: <TableOutlined />, label: 'Tabel' },
+];
+
+export function Sidebar({ isMobile, open, onClose }: SidebarProps) {
   const nav = useNavigate();
   const loc = useLocation();
 
-  const items = [
-    { key: '/', icon: <QuestionCircleOutlined />, label: 'Nõuded' },
-    { key: '/article', icon: <FileTextOutlined />, label: 'Artikkel' },
-    { key: '/table', icon: <TableOutlined />, label: 'Tabel' },
-  ];
+  const classNames = ['tw-sider'];
+
+  if (isMobile) {
+    classNames.push('tw-sider--mobile');
+
+    if (open) {
+      classNames.push('tw-sider--open');
+    }
+  }
 
   return (
     <Sider
-      className="tw-sider"
+      className={classNames.join(' ')}
       theme="light"
-      /* Desktop: never collapsed; Mobile: controlled collapse */
-      collapsed={isMobile ? collapsed : false}
-      collapsedWidth={isMobile ? 0 : 220}
       width={220}
-      /* No built-in trigger; we render a button only on mobile */
       trigger={null}
-      /* Auto-collapse when crossing breakpoint */
-      breakpoint="lg"
-      onBreakpoint={(broken) => setCollapsed(broken)}
+      aria-hidden={isMobile && !open}
     >
       <div className="tw-logo" style={{ gap: 8 }}>
         <img src={logo} alt="Trinidad Wiseman" style={{ height: 28, width: 'auto' }} />
-        {/* Show toggle button ONLY on mobile */}
-        {isMobile && (
-          <Button
-            aria-label={collapsed ? 'Ava külgriba' : 'Sulge külgriba'}
-            type="text"
-            onClick={() => setCollapsed((v) => !v)}
-            icon={collapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-            style={{ marginLeft: 'auto' }}
-          />
-        )}
       </div>
 
       <Menu
         mode="inline"
         selectedKeys={[loc.pathname]}
-        items={items}
+        items={menuItems}
         onClick={({ key }) => {
           nav(String(key));
-          if (isMobile) setCollapsed(true); // close after navigating on mobile
+          if (isMobile && onClose) {
+            onClose();
+          }
         }}
       />
     </Sider>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string) {
+  const getMatches = () => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.matchMedia(query).matches;
+  };
+
+  const [matches, setMatches] = useState(getMatches);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    setMatches(mediaQueryList.matches);
+
+    mediaQueryList.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQueryList.removeEventListener('change', handleChange);
+    };
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- add a fixed mobile header with burger toggle that controls the sidebar on screens narrower than 960px
- refactor the sidebar to accept external visibility state and animate in/out on small viewports while keeping it visible on desktop
- add a shared `useMediaQuery` hook and supporting styles for the responsive layout adjustments

## Testing
- npm run lint