### PR TITLE
feat: refresh table styling and pagination

### DIFF
--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -28,6 +28,12 @@ body {
   line-height: 1.6;
 }
 
+.home-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .tw-layout {
   position: relative;
   min-height: 100vh;
@@ -57,7 +63,7 @@ body {
 }
 
 .tw-content::before,
-.tw-content::after {
+.ant-layout-content::after {
   content: "";
   position: absolute;
   pointer-events: none;
@@ -243,26 +249,6 @@ p {
   font-weight: 700;
 }
 
-.tw-table {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-lg);
-  padding: var(--space-lg) var(--space-xl);
-  border-radius: 1.5rem;
-  background: radial-gradient(120% 120% at 50% 0%, rgba(113, 101, 176, 0.65) 0%, rgba(62, 53, 110, 0.92) 55%, rgba(47, 40, 86, 0.98) 100%);
-  box-shadow: 0 32px 48px rgba(11, 7, 34, 0.45);
-  backdrop-filter: blur(18px);
-}
-
-.tw-table__controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-sm);
-  color: rgba(255, 255, 255, 0.72);
-}
-
 .tw-table__label {
   display: flex;
   align-items: center;
@@ -313,10 +299,7 @@ p {
 }
 
 .tw-table__wrapper {
-  border-radius: 1.25rem;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, rgba(26, 20, 56, 0.35) 100%);
+  overflow: auto;
 }
 
 .tw-table__grid {
@@ -327,15 +310,15 @@ p {
 }
 
 .tw-table__head {
-  background: rgba(255, 255, 255, 0.08);
+  background: #333333;
 }
 
 .tw-table__header {
   text-align: left;
   padding: 0.875rem 1.25rem;
   border: none;
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-size: 1rem;
+  font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.72);
@@ -364,14 +347,15 @@ p {
 
 .tw-table__row {
   transition: background-color 0.2s ease;
+  border-bottom: #fff .0625rem solid;
 }
 
 .tw-table__row:nth-child(odd) {
-  background: rgba(255, 255, 255, 0.04);
+  background: none;
 }
 
 .tw-table__row:nth-child(even) {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255,255,255,0.1);
 }
 
 .tw-table__row:hover {
@@ -379,10 +363,11 @@ p {
 }
 
 .tw-table__cell {
-  padding: 0.875rem 1.25rem;
+  padding: .625rem 1rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.14);
-  font-size: 0.9375rem;
+  font-size: 1rem;
   color: #f4f5ff;
+  width: 20%;
 }
 
 .tw-table__row:last-child .tw-table__cell {
@@ -395,7 +380,7 @@ p {
   justify-content: center;
   gap: var(--space-sm);
   flex-wrap: wrap;
-  margin-top: var(--space-sm);
+  margin-top: var(--space-lg);
 }
 
 .tw-table__pagination-btn {
@@ -425,7 +410,9 @@ p {
 }
 
 .tw-table__pagination-btn--nav {
-  background: rgba(255, 255, 255, 0.12);
+  border: none;
+  font-size: 2rem;
+  font-weight: 200;
 }
 
 .tw-table__pagination-btn--nav:hover:not(:disabled) {

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -246,40 +246,99 @@ p {
 .tw-table {
   display: flex;
   flex-direction: column;
-  gap: var(--space-md);
+  gap: var(--space-lg);
+  padding: var(--space-lg) var(--space-xl);
+  border-radius: 1.5rem;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(113, 101, 176, 0.65) 0%, rgba(62, 53, 110, 0.92) 55%, rgba(47, 40, 86, 0.98) 100%);
+  box-shadow: 0 32px 48px rgba(11, 7, 34, 0.45);
+  backdrop-filter: blur(18px);
 }
 
 .tw-table__controls {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-sm);
   align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .tw-table__label {
   display: flex;
   align-items: center;
-  gap: var(--space-xs);
-  font-weight: 500;
+  gap: var(--space-sm);
+  font-weight: 600;
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .tw-table__page-size-select {
   width: 7.5rem;
 }
 
+.tw-table__page-size-select .ant-select-selector {
+  background: rgba(255, 255, 255, 0.12) !important;
+  border: 1px solid rgba(255, 255, 255, 0.24) !important;
+  border-radius: 9999px !important;
+  padding: 0 var(--space-sm) !important;
+  height: 2.5rem !important;
+  display: flex;
+  align-items: center;
+  box-shadow: none !important;
+}
+
+.tw-table__page-size-select .ant-select-selection-item,
+.tw-table__page-size-select .ant-select-selection-placeholder {
+  color: #ffffff !important;
+  font-weight: 500;
+}
+
+.tw-table__page-size-select .ant-select-arrow,
+.tw-table__page-size-select .ant-select-selection-item {
+  color: #ffffff;
+}
+
+.tw-table__page-size-select.ant-select-focused .ant-select-selector,
+.tw-table__page-size-select.ant-select-open .ant-select-selector {
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3) !important;
+}
+
 .tw-table__range {
   font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.tw-table__wrapper {
+  border-radius: 1.25rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, rgba(26, 20, 56, 0.35) 100%);
 }
 
 .tw-table__grid {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
+  color: inherit;
+}
+
+.tw-table__head {
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .tw-table__header {
   text-align: left;
-  border-bottom: 1px solid var(--table-border);
-  padding: var(--space-xs) var(--space-sm);
+  padding: 0.875rem 1.25rem;
+  border: none;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .tw-table__sort {
@@ -289,19 +348,111 @@ p {
   cursor: pointer;
   font: inherit;
   color: inherit;
+  width: 100%;
+  text-align: left;
+}
+
+.tw-table__sort:focus-visible,
+.tw-table__pagination-btn:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.85);
+  outline-offset: 2px;
+}
+
+.tw-table__body {
+  background: transparent;
+}
+
+.tw-table__row {
+  transition: background-color 0.2s ease;
+}
+
+.tw-table__row:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.tw-table__row:nth-child(even) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.tw-table__row:hover {
+  background: rgba(255, 255, 255, 0.15);
 }
 
 .tw-table__cell {
-  padding: var(--space-xs) var(--space-sm);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 0.875rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+  font-size: 0.9375rem;
+  color: #f4f5ff;
+}
+
+.tw-table__row:last-child .tw-table__cell {
+  border-bottom: none;
 }
 
 .tw-table__pagination {
-  margin-top: var(--space-md);
   display: flex;
-  gap: var(--space-xs);
-  flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  margin-top: var(--space-sm);
+}
+
+.tw-table__pagination-btn {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: transparent;
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.tw-table__pagination-btn:hover:not(:disabled) {
+  border-color: #ffffff;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.tw-table__pagination-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tw-table__pagination-btn--nav {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.tw-table__pagination-btn--nav:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.tw-table__pagination-btn--active {
+  background: #ffffff;
+  color: #3d336d;
+  border-color: #ffffff;
+  box-shadow: 0 12px 24px rgba(10, 6, 32, 0.35);
+}
+
+@media (max-width: 640px) {
+  .tw-table {
+    padding: var(--space-lg);
+  }
+
+  .tw-table__header {
+    font-size: 0.6875rem;
+  }
+
+  .tw-table__pagination-btn {
+    width: 2.25rem;
+    height: 2.25rem;
+    font-size: 0.875rem;
+  }
 }
 
 .tw-mobile-header {

--- a/src/components/table/CustomTable.tsx
+++ b/src/components/table/CustomTable.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react';
-import { Select } from 'antd';
 import type { Row } from '@/types';
 import { nextDir, type SortDir, type SortState } from '@/utils/sort';
 import { usePagination } from '@/hooks/usePagination';
@@ -79,7 +78,7 @@ export default function CustomTable({ rows }: Props) {
     });
   }, [rows, sort, activeCol]);
 
-  const { data, page, pages, setPage, perPage, setPerPage, range, total } =
+  const { data, page, pages, setPage } =
     usePagination<Row>(sorted, 10);
 
   const visiblePages = useMemo(() => {
@@ -100,21 +99,6 @@ export default function CustomTable({ rows }: Props) {
 
   return (
     <div className="tw-table">
-      <div className="tw-table__controls">
-        <label className="tw-table__label">
-          <span>Items per page</span>
-          <Select
-            value={perPage}
-            onChange={(v) => { setPerPage(v); setPage(1); }}
-            options={[5, 10, 20, 50].map(v => ({ value: v, label: String(v) }))}
-            aria-label="Items per page"
-            className="tw-table__page-size-select"
-          />
-        </label>
-        <div className="tw-table__range" aria-live="polite" aria-atomic="true">
-          Näitan {range[0]}–{range[1]} / {total}
-        </div>
-      </div>
       <div className="tw-table__wrapper">
         <table role="table" className="tw-table__grid">
           <thead className="tw-table__head">

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,8 +1,8 @@
 export default function Home() {
   return (
-    <section aria-labelledby="welcome">
-      <h1 id="welcome">Welcome</h1>
-      <p>This is the index route of the React + TypeScript homework app.</p>
+    <section aria-labelledby="welcome" className="home-page">
+      <h1 id="welcome">Tere tulemast!</h1>
+      <p>See on React + TypeScript kodutöö rakenduse avaleht.</p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the CustomTable markup to wrap the grid and expose hooks for the new visual treatment
- implement a 5-page windowed paginator that keeps the active page centered when possible and exposes accessible controls
- extend the table theme with the gradient card, zebra rows, custom select chrome, and circular pagination indicators shown in the design

## Testing
- npm run lint
- npm run build