### PR TITLE
refactor: centralize hardcoded strings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import AppLayout from '@/components/layout/AppLayout';
 import Home from '@/pages/Home';
 import ArticlePage from '@/pages/Article';
 import TablePage from '@/pages/Table';
+import { ROUTES } from '@/constants';
 import './assets/styles/global.css';
 import './assets/styles/fonts.css';
 import './assets/styles/theme.css';
@@ -18,9 +19,9 @@ export default function App() {
         <BrowserRouter>
           <Routes>
             <Route element={<AppLayout />}>
-              <Route path="/" element={<Home />} />
-              <Route path="/article" element={<ArticlePage />} />
-              <Route path="/table" element={<TablePage />} />
+              <Route path={ROUTES.HOME} element={<Home />} />
+              <Route path={ROUTES.ARTICLE} element={<ArticlePage />} />
+              <Route path={ROUTES.TABLE} element={<TablePage />} />
             </Route>
           </Routes>
         </BrowserRouter>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -4,11 +4,10 @@ import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { MobileHeader } from './MobileHeader';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
-
-const MOBILE_BREAKPOINT = '(max-width: 959.98px)';
+import { MEDIA_QUERIES } from '@/constants';
 
 export default function AppLayout() {
-  const isMobile = useMediaQuery(MOBILE_BREAKPOINT);
+  const isMobile = useMediaQuery(MEDIA_QUERIES.MOBILE);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   useEffect(() => {

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,6 +1,7 @@
 import { CloseOutlined, MenuOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
 import logo from '@/assets/images/logo.svg';
+import { BRAND_COPY, MOBILE_HEADER_COPY } from '@/constants';
 
 type MobileHeaderProps = {
   isOpen: boolean;
@@ -11,7 +12,7 @@ export function MobileHeader({ isOpen, onToggle }: MobileHeaderProps) {
   return (
     <header className="tw-mobile-header">
       <Button
-        aria-label={isOpen ? 'Sulge külgriba' : 'Ava külgriba'}
+        aria-label={isOpen ? MOBILE_HEADER_COPY.CLOSE_SIDEBAR : MOBILE_HEADER_COPY.OPEN_SIDEBAR}
         aria-expanded={isOpen}
         type="text"
         onClick={onToggle}
@@ -19,7 +20,7 @@ export function MobileHeader({ isOpen, onToggle }: MobileHeaderProps) {
         className="tw-mobile-header__toggle"
       />
       <div className="tw-mobile-header__logo">
-        <img src={logo} alt="Trinidad Wiseman" />
+        <img src={logo} alt={BRAND_COPY.NAME} />
       </div>
     </header>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import type { MenuProps } from 'antd';
 import Sider from 'antd/es/layout/Sider';
 import { useLocation, useNavigate } from 'react-router-dom';
 import logo from '@/assets/images/logo.svg';
+import { BRAND_COPY, NAVIGATION_COPY, ROUTES } from '@/constants';
 
 type SidebarProps = {
   isMobile: boolean;
@@ -12,9 +13,9 @@ type SidebarProps = {
 };
 
 const menuItems: MenuProps['items'] = [
-  { key: '/', icon: <StarOutlined />, label: 'Avaleht' },
-  { key: '/article', icon: <FileTextOutlined />, label: 'Artikkel' },
-  { key: '/table', icon: <TableOutlined />, label: 'Tabel' },
+  { key: ROUTES.HOME, icon: <StarOutlined />, label: NAVIGATION_COPY.HOME },
+  { key: ROUTES.ARTICLE, icon: <FileTextOutlined />, label: NAVIGATION_COPY.ARTICLE },
+  { key: ROUTES.TABLE, icon: <TableOutlined />, label: NAVIGATION_COPY.TABLE },
 ];
 
 export function Sidebar({ isMobile, open, onClose }: SidebarProps) {
@@ -40,7 +41,7 @@ export function Sidebar({ isMobile, open, onClose }: SidebarProps) {
       aria-hidden={isMobile && !open}
     >
       <div className="tw-logo">
-        <img src={logo} alt="Trinidad Wiseman" />
+        <img src={logo} alt={BRAND_COPY.NAME} />
       </div>
 
       <Menu

--- a/src/components/table/CustomTable.tsx
+++ b/src/components/table/CustomTable.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import type { Row } from '@/types';
 import { nextDir, type SortDir, type SortState } from '@/utils/sort';
 import { usePagination } from '@/hooks/usePagination';
+import { TABLE_A11Y_COPY, TABLE_COLUMN_LABELS } from '@/constants';
 
 interface Props { rows: Row[]; }
 
@@ -37,17 +38,23 @@ function defaultCompare(a: Comparable, b: Comparable): number {
 
 /** Column setup: clear, extensible, no dynamic indexing */
 const COLUMNS: Column<Row>[] = [
-  { key: 'firstName', label: 'Eesnimi', accessor: r => r.firstName },
-  { key: 'lastName',  label: 'Perekonnanimi', accessor: r => r.lastName },
-  { key: 'sex',       label: 'Sugu', accessor: r => r.sex },
+  { key: 'firstName', label: TABLE_COLUMN_LABELS.FIRST_NAME, accessor: r => r.firstName },
+  { key: 'lastName',  label: TABLE_COLUMN_LABELS.LAST_NAME, accessor: r => r.lastName },
+  { key: 'sex',       label: TABLE_COLUMN_LABELS.SEX, accessor: r => r.sex },
   // unix seconds → sort numerically
-  { key: 'birthDate', label: 'Sünnikuupäev', accessor: r => r.birthDate },
+  { key: 'birthDate', label: TABLE_COLUMN_LABELS.BIRTH_DATE, accessor: r => r.birthDate },
   // phone: sort by numeric digits (natural order)
-  { key: 'phone',     label: 'Telefon', accessor: r => Number(r.phone.replace(/\D/g, '')) },
+  { key: 'phone',     label: TABLE_COLUMN_LABELS.PHONE, accessor: r => Number(r.phone.replace(/\D/g, '')) },
 ];
 
 function SortHeader({ label, active, dir }: { label: string; active: boolean; dir: SortDir }) {
-  const suffix = !active ? '' : dir === 'asc' ? ' ▲' : dir === 'desc' ? ' ▼' : '';
+  const suffix = !active
+    ? ''
+    : dir === 'asc'
+      ? TABLE_A11Y_COPY.SORT_ASC_SUFFIX
+      : dir === 'desc'
+        ? TABLE_A11Y_COPY.SORT_DESC_SUFFIX
+        : '';
   return <span aria-live="polite">{label}{suffix}</span>;
 }
 
@@ -115,7 +122,7 @@ export default function CustomTable({ rows }: Props) {
                   >
                     <button
                       onClick={() => cycle(key)}
-                      aria-label={`Sorteeri veerg: ${label}`}
+                      aria-label={`${TABLE_A11Y_COPY.SORT_BUTTON_PREFIX}${label}`}
                       type="button"
                       className="tw-table__sort"
                     >
@@ -140,15 +147,15 @@ export default function CustomTable({ rows }: Props) {
         </table>
       </div>
 
-      <nav aria-label="Lehekülgede vahetus" className="tw-table__pagination">
+      <nav aria-label={TABLE_A11Y_COPY.PAGINATION_ARIA_LABEL} className="tw-table__pagination">
         <button
           type="button"
           className="tw-table__pagination-btn tw-table__pagination-btn--nav"
           onClick={() => setPage(page - 1)}
           disabled={page <= 1}
-          aria-label="Eelmine leht"
+          aria-label={TABLE_A11Y_COPY.PREVIOUS_PAGE}
         >
-          ‹
+          {TABLE_A11Y_COPY.PREVIOUS_ICON}
         </button>
         {visiblePages.map(p => (
           <button
@@ -166,9 +173,9 @@ export default function CustomTable({ rows }: Props) {
           className="tw-table__pagination-btn tw-table__pagination-btn--nav"
           onClick={() => setPage(page + 1)}
           disabled={page >= pages}
-          aria-label="Järgmine leht"
+          aria-label={TABLE_A11Y_COPY.NEXT_PAGE}
         >
-          ›
+          {TABLE_A11Y_COPY.NEXT_ICON}
         </button>
       </nav>
     </div>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,0 +1,91 @@
+export const ROUTES = {
+  HOME: '/',
+  ARTICLE: '/article',
+  TABLE: '/table',
+} as const;
+
+export const MEDIA_QUERIES = {
+  MOBILE: '(max-width: 959.98px)',
+} as const;
+
+export const BRAND_COPY = {
+  NAME: 'Trinidad Wiseman',
+} as const;
+
+export const NAVIGATION_COPY = {
+  HOME: 'Avaleht',
+  ARTICLE: 'Artikkel',
+  TABLE: 'Tabel',
+} as const;
+
+export const MOBILE_HEADER_COPY = {
+  OPEN_SIDEBAR: 'Ava külgriba',
+  CLOSE_SIDEBAR: 'Sulge külgriba',
+} as const;
+
+export const HOME_PAGE_COPY = {
+  HEADING_ID: 'welcome',
+  TITLE: 'Tere tulemast!',
+  DESCRIPTION: 'See on React + TypeScript kodutöö rakenduse avaleht.',
+} as const;
+
+export const ARTICLE_PAGE_COPY = {
+  LOAD_ERROR: 'Failed to load article',
+  INTRO_SECTION_ARIA_LABEL: 'Introduction',
+  BODY_SECTION_ARIA_LABEL: 'Body',
+} as const;
+
+export const ARTICLE_PAGE_IDS = {
+  TITLE: 'article-title',
+} as const;
+
+export const TABLE_PAGE_COPY = {
+  TITLE: 'NIMEKIRI',
+  LOAD_ERROR: 'Failed to load table data',
+} as const;
+
+export const TABLE_COLUMN_LABELS = {
+  FIRST_NAME: 'Eesnimi',
+  LAST_NAME: 'Perekonnanimi',
+  SEX: 'Sugu',
+  BIRTH_DATE: 'Sünnikuupäev',
+  PHONE: 'Telefon',
+} as const;
+
+export const TABLE_A11Y_COPY = {
+  PAGINATION_ARIA_LABEL: 'Lehekülgede vahetus',
+  PREVIOUS_PAGE: 'Eelmine leht',
+  NEXT_PAGE: 'Järgmine leht',
+  SORT_BUTTON_PREFIX: 'Sorteeri veerg: ',
+  SORT_ASC_SUFFIX: ' ▲',
+  SORT_DESC_SUFFIX: ' ▼',
+  PREVIOUS_ICON: '‹',
+  NEXT_ICON: '›',
+} as const;
+
+export const API_RESOURCE_IDS = {
+  ARTICLE: '972d2b8a',
+  TABLE: 'twn-list',
+} as const;
+
+export const API_ENDPOINTS = {
+  ARTICLE: `https://proovitoo.twn.ee/api/list/${API_RESOURCE_IDS.ARTICLE}`,
+  LIST: 'https://proovitoo.twn.ee/api/list',
+} as const;
+
+export const QUERY_KEYS = {
+  ARTICLE: ['article', API_RESOURCE_IDS.ARTICLE] as const,
+  TABLE: ['table', API_RESOURCE_IDS.TABLE] as const,
+} as const;
+
+export const SEX_CODES = {
+  MALE: 'm',
+  FEMALE: 'f',
+} as const;
+
+export const SEX_LABELS = {
+  MALE: 'Mees',
+  FEMALE: 'Naine',
+} as const;
+
+export type SexLabel = (typeof SEX_LABELS)[keyof typeof SEX_LABELS];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,3 @@
-export const API = {
-  ARTICLE: '/api/article',
-  TABLE: '/api/table'
-} as const;
+export * from './constants';
 
 export const BREAKPOINTS = { mobile: 768, tablet: 1024, desktop: 1200 };

--- a/src/pages/Article/index.tsx
+++ b/src/pages/Article/index.tsx
@@ -1,6 +1,7 @@
 import { Alert, Card, Skeleton, Tag, Image, Divider } from 'antd';
 import { useEffect } from 'react';
 import { useArticle } from '@/services/api';
+import { ARTICLE_PAGE_COPY, ARTICLE_PAGE_IDS } from '@/constants';
 
 export default function ArticlePage() {
   const { data, isLoading, isError, error } = useArticle();
@@ -17,7 +18,7 @@ export default function ArticlePage() {
     return (
       <Alert
         type="error"
-        message="Failed to load article"
+        message={ARTICLE_PAGE_COPY.LOAD_ERROR}
         description={String((error as Error)?.message ?? '')}
       />
     );
@@ -26,16 +27,16 @@ export default function ArticlePage() {
   if (!data) return null;
 
   return (
-    <article className="article-page" aria-labelledby="article-title">
-      
+    <article className="article-page" aria-labelledby={ARTICLE_PAGE_IDS.TITLE}>
+
       <Card className="article-card">
         <header className="article-header">
-          <h1 className="page-title">{data.title}</h1>
+          <h1 id={ARTICLE_PAGE_IDS.TITLE} className="page-title">{data.title}</h1>
         </header>
 
         {/* Intro (HTML) */}
         {data.intro && (
-          <section className="article-intro" aria-label="Introduction">
+          <section className="article-intro" aria-label={ARTICLE_PAGE_COPY.INTRO_SECTION_ARIA_LABEL}>
             <div dangerouslySetInnerHTML={{ __html: data.intro }} />
           </section>
         )}
@@ -57,7 +58,7 @@ export default function ArticlePage() {
 
         {/* Body (HTML) */}
         {data.body && (
-          <section className="article-body" aria-label="Body">
+          <section className="article-body" aria-label={ARTICLE_PAGE_COPY.BODY_SECTION_ARIA_LABEL}>
             <div dangerouslySetInnerHTML={{ __html: data.body }} />
           </section>
         )}

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,8 +1,12 @@
+import { HOME_PAGE_COPY } from '@/constants';
+
 export default function Home() {
   return (
-    <section aria-labelledby="welcome" className="home-page">
-      <h1 className="page-title">Tere tulemast!</h1>
-      <p>See on React + TypeScript kodutöö rakenduse avaleht.</p>
+    <section aria-labelledby={HOME_PAGE_COPY.HEADING_ID} className="home-page">
+      <h1 id={HOME_PAGE_COPY.HEADING_ID} className="page-title">
+        {HOME_PAGE_COPY.TITLE}
+      </h1>
+      <p>{HOME_PAGE_COPY.DESCRIPTION}</p>
     </section>
   );
 }

--- a/src/pages/Table/index.tsx
+++ b/src/pages/Table/index.tsx
@@ -1,16 +1,24 @@
 import { Alert, Card, Skeleton } from 'antd';
 import { useTable } from '@/services/api';
 import CustomTable from '@/components/table/CustomTable';
+import { TABLE_PAGE_COPY } from '@/constants';
 
 export default function TablePage() {
   const { data, isLoading, isError, error } = useTable();
 
   if (isLoading) return <Skeleton active paragraph={{ rows: 6 }} />;
-  if (isError) return <Alert type="error" message="Failed to load table data" description={String((error as Error)?.message ?? '')} />;
+  if (isError)
+    return (
+      <Alert
+        type="error"
+        message={TABLE_PAGE_COPY.LOAD_ERROR}
+        description={String((error as Error)?.message ?? '')}
+      />
+    );
 
   return (
     <>
-      <h1 className="page-title">NIMEKIRI</h1>
+      <h1 className="page-title">{TABLE_PAGE_COPY.TITLE}</h1>
       <Card>
         <CustomTable rows={data ?? []} />
       </Card>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import type { Article, Row, TwnListItem } from '@/types';
+import { API_ENDPOINTS, QUERY_KEYS, SEX_CODES, SEX_LABELS } from '@/constants';
 
 
 export function unixToDate(unixSec: number) {
@@ -9,14 +10,12 @@ export function unixToDate(unixSec: number) {
 }
 
 export async function getArticle(signal?: AbortSignal): Promise<Article> {
-  const url = 'https://proovitoo.twn.ee/api/list/972d2b8a';
-  const res = await axios.get<Article>(url, { signal });
+  const res = await axios.get<Article>(API_ENDPOINTS.ARTICLE, { signal });
   return res.data;
 }
 
 async function getTwnList(signal?: AbortSignal): Promise<TwnListItem[]> {
-  const url = 'https://proovitoo.twn.ee/api/list';
-  const res = await axios.get<{ list: TwnListItem[] }>(url, { signal });
+  const res = await axios.get<{ list: TwnListItem[] }>(API_ENDPOINTS.LIST, { signal });
   return res.data.list;
 }
 
@@ -25,7 +24,7 @@ export async function getTable(signal?: AbortSignal): Promise<Row[]> {
   return list.map((p) => ({
     firstName: p.firstname,
     lastName: p.surname,
-    sex: p.sex === 'm' ? 'Mees' : 'Naine',
+    sex: p.sex === SEX_CODES.MALE ? SEX_LABELS.MALE : SEX_LABELS.FEMALE,
     birthDate: p.date,      // keep numeric; UI will render dd.MM.yyyy
     phone: p.phone,
   }));
@@ -33,7 +32,7 @@ export async function getTable(signal?: AbortSignal): Promise<Row[]> {
 
 export function useArticle(): UseQueryResult<Article> {
   return useQuery({
-    queryKey: ['article', '972d2b8a'],
+    queryKey: QUERY_KEYS.ARTICLE,
     queryFn: ({ signal }) => getArticle(signal),
     retry: 2
   });
@@ -41,7 +40,7 @@ export function useArticle(): UseQueryResult<Article> {
 
 export function useTable(): UseQueryResult<Row[]> {
   return useQuery({
-    queryKey: ['table', 'twn-list'],
+    queryKey: QUERY_KEYS.TABLE,
     queryFn: ({ signal }) => getTable(signal),
     retry: 2,
     staleTime: 60_000,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { SexLabel } from '@/constants';
+
 export type Sex = 'm' | 'f';
 
 export interface TwnImage {
@@ -47,7 +49,7 @@ export interface Article {
 export interface Row {
   firstName: string;
   lastName: string;
-  sex: 'Mees' | 'Naine';
+  sex: SexLabel;
   birthDate: number; // unix seconds; we'll format in the UI
   phone: string;
 }


### PR DESCRIPTION
## Summary
- add a shared constants module that groups application copy by usage
- update components, pages, and services to reference the centralized values
- expose reusable identifiers for API configuration and domain-specific labels

## Testing
- npm run lint