### PR TITLE
Add comprehensive tests and configure Vitest environment

### DIFF
--- a/src/components/layout/__tests__/AppLayout.test.tsx
+++ b/src/components/layout/__tests__/AppLayout.test.tsx
@@ -1,0 +1,169 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AppLayout from '../AppLayout';
+import * as SidebarModule from '../Sidebar';
+import { Sidebar } from '../Sidebar';
+import { MobileHeader } from '../MobileHeader';
+import { MOBILE_HEADER_COPY, NAVIGATION_COPY, ROUTES } from '@/constants';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: vi.fn(),
+}));
+
+const useMediaQueryMock = vi.mocked(useMediaQuery);
+
+const renderWithRouter = () =>
+  render(
+    <MemoryRouter initialEntries={[ROUTES.HOME]}>
+      <Routes>
+        <Route path={ROUTES.HOME} element={<AppLayout />}>
+          <Route index element={<div>Home</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+
+afterEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe('AppLayout', () => {
+  it('renders desktop layout without mobile header and keeps sidebar open', () => {
+    useMediaQueryMock.mockReturnValue(false);
+    const sidebarSpy = vi.spyOn(SidebarModule, 'Sidebar');
+
+    const { container } = renderWithRouter();
+
+    expect(screen.queryByRole('button', { name: MOBILE_HEADER_COPY.OPEN_SIDEBAR })).toBeNull();
+
+    const sidebarCall = sidebarSpy.mock.calls.at(-1)?.[0];
+    expect(sidebarCall?.isMobile).toBe(false);
+    expect(sidebarCall?.open).toBe(true);
+
+    const sidebar = container.querySelector('.tw-sider');
+    expect(sidebar).not.toHaveClass('tw-sider--mobile');
+    expect(sidebar?.getAttribute('aria-hidden')).not.toBe('true');
+
+    sidebarSpy.mockRestore();
+  });
+
+  it('toggles sidebar visibility on mobile via the header button', async () => {
+    useMediaQueryMock.mockReturnValue(true);
+    const sidebarSpy = vi.spyOn(SidebarModule, 'Sidebar');
+
+    renderWithRouter();
+
+    const toggle = screen.getByRole('button', { name: MOBILE_HEADER_COPY.OPEN_SIDEBAR });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    const sidebarInitial = sidebarSpy.mock.calls[0]?.[0];
+    expect(sidebarInitial?.isMobile).toBe(true);
+    expect(sidebarInitial?.open).toBe(false);
+
+    const user = userEvent.setup();
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-label', MOBILE_HEADER_COPY.CLOSE_SIDEBAR);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    const sidebarAfterToggle = sidebarSpy.mock.calls.at(-1)?.[0];
+    expect(sidebarAfterToggle?.open).toBe(true);
+
+    const sidebar = document.querySelector('.tw-sider');
+    expect(sidebar?.getAttribute('aria-hidden')).toBe('false');
+
+    sidebarSpy.mockRestore();
+  });
+});
+
+describe('Sidebar', () => {
+  it('applies desktop styling and does not trigger onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    const { container } = render(
+      <MemoryRouter initialEntries={[ROUTES.HOME]}>
+        <Sidebar isMobile={false} open onClose={onClose} />
+      </MemoryRouter>,
+    );
+
+    const sidebar = container.querySelector('.tw-sider');
+    expect(sidebar).not.toHaveClass('tw-sider--mobile');
+    expect(sidebar).not.toHaveClass('tw-sider--open');
+
+    const menu = container.querySelector('.ant-menu');
+    expect(menu).toBeInTheDocument();
+
+    await user.click(within(menu as HTMLElement).getByText(NAVIGATION_COPY.TABLE));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows mobile modifiers and calls onClose when a menu item is selected', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    const { container } = render(
+      <MemoryRouter initialEntries={[ROUTES.HOME]}>
+        <Sidebar isMobile open onClose={onClose} />
+      </MemoryRouter>,
+    );
+
+    const sidebar = container.querySelector('.tw-sider');
+    expect(sidebar).toHaveClass('tw-sider--mobile', 'tw-sider--open');
+    expect(sidebar).toHaveAttribute('aria-hidden', 'false');
+
+    const menu = container.querySelector('.ant-menu');
+    expect(menu).toBeInTheDocument();
+
+    await user.click(within(menu as HTMLElement).getByText(NAVIGATION_COPY.ARTICLE));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the sidebar when closed on mobile', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={[ROUTES.HOME]}>
+        <Sidebar isMobile open={false} />
+      </MemoryRouter>,
+    );
+
+    const sidebar = container.querySelector('.tw-sider');
+    expect(sidebar).toHaveClass('tw-sider--mobile');
+    expect(sidebar).not.toHaveClass('tw-sider--open');
+    expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+describe('MobileHeader', () => {
+  it('switches labels based on the open state', () => {
+    const { rerender } = render(
+      <MobileHeader
+        isOpen={false}
+        onToggle={() => {
+          /* noop */
+        }}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: MOBILE_HEADER_COPY.OPEN_SIDEBAR });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    rerender(
+      <MobileHeader
+        isOpen
+        onToggle={() => {
+          /* noop */
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: MOBILE_HEADER_COPY.CLOSE_SIDEBAR })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+});

--- a/src/components/table/__tests__/CustomTable.test.tsx
+++ b/src/components/table/__tests__/CustomTable.test.tsx
@@ -1,0 +1,176 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import CustomTable from '../CustomTable';
+import { TABLE_A11Y_COPY, TABLE_COLUMN_LABELS } from '@/constants';
+import type { Row } from '@/types';
+
+const baseTimestamp = 1609459200; // 01.01.2021
+
+afterEach(() => {
+  cleanup();
+});
+
+function createRows(total = 75): Row[] {
+  const seed: Row[] = [
+    {
+      firstName: 'Charlie',
+      lastName: 'Zulu',
+      sex: 'Mees',
+      birthDate: baseTimestamp + 86400 * 2,
+      phone: '+372 555-0100',
+    },
+    {
+      firstName: 'Alpha',
+      lastName: 'Mike',
+      sex: 'Naine',
+      birthDate: baseTimestamp,
+      phone: '+372 555-099',
+    },
+    {
+      firstName: 'Bravo',
+      lastName: 'Alpha',
+      sex: 'Mees',
+      birthDate: baseTimestamp + 86400,
+      phone: '+372 555 002',
+    },
+  ];
+
+  const rows = seed.slice(0, Math.min(total, seed.length));
+
+  for (let i = rows.length; i < total; i += 1) {
+    rows.push({
+      firstName: `Person${i}`,
+      lastName: `Last${i}`,
+      sex: i % 2 === 0 ? 'Mees' : 'Naine',
+      birthDate: baseTimestamp + i * 86400,
+      phone: `555000${String(i).padStart(2, '0')}`,
+    });
+  }
+
+  return rows;
+}
+
+describe('CustomTable', () => {
+  it('formats birth dates and sorts phone numbers numerically', async () => {
+    const rows = createRows(3);
+    const user = userEvent.setup();
+    render(<CustomTable rows={rows} />);
+
+    const firstDataRow = screen.getAllByRole('row')[1];
+    expect(within(firstDataRow).getByText(rows[0].firstName)).toBeInTheDocument();
+    expect(within(firstDataRow).getByText('03.01.2021')).toBeInTheDocument();
+    expect(within(firstDataRow).getByText(rows[0].phone)).toBeInTheDocument();
+
+    const phoneHeaderButton = within(screen.getAllByRole('columnheader')[4]).getByRole('button', {
+      name: `${TABLE_A11Y_COPY.SORT_BUTTON_PREFIX}${TABLE_COLUMN_LABELS.PHONE}`,
+    });
+
+    await user.click(phoneHeaderButton);
+
+    const expectedPhoneOrder = [...rows].sort(
+      (a, b) => Number(a.phone.replace(/\D/g, '')) - Number(b.phone.replace(/\D/g, '')),
+    );
+    const sortedFirstRow = screen.getAllByRole('row')[1];
+    expect(within(sortedFirstRow).getByText(expectedPhoneOrder[0].firstName)).toBeInTheDocument();
+    expect(within(sortedFirstRow).getByText(expectedPhoneOrder[0].phone)).toBeInTheDocument();
+  });
+
+  it('cycles sort state and updates aria attributes', async () => {
+    const rows = createRows(15);
+    const user = userEvent.setup();
+    render(<CustomTable rows={rows} />);
+
+    const firstNameHeader = screen.getAllByRole('columnheader')[0];
+    expect(firstNameHeader).toHaveAttribute('aria-sort', 'none');
+
+    const sortButton = within(firstNameHeader).getByRole('button', {
+      name: `${TABLE_A11Y_COPY.SORT_BUTTON_PREFIX}${TABLE_COLUMN_LABELS.FIRST_NAME}`,
+    });
+
+    const readFirstColumn = () =>
+      Array.from(document.querySelectorAll<HTMLTableRowElement>('.tw-table__body .tw-table__row'))
+        .slice(0, 5)
+        .map((row) => row.cells[0]?.textContent ?? '');
+
+    const collator = new Intl.Collator('et', { sensitivity: 'base', numeric: true });
+    const expectedAsc = [...rows].sort((a, b) => collator.compare(a.firstName, b.firstName));
+    const expectedDesc = [...expectedAsc].reverse();
+
+    await user.click(sortButton);
+    expect(firstNameHeader).toHaveAttribute('aria-sort', 'ascending');
+    expect(
+      within(firstNameHeader).getByText(
+        `${TABLE_COLUMN_LABELS.FIRST_NAME} ${TABLE_A11Y_COPY.SORT_ASC_SUFFIX.trim()}`,
+      ),
+    ).toBeInTheDocument();
+    const ascValues = readFirstColumn();
+    expect(ascValues[0]).toBe(expectedAsc[0].firstName);
+
+    await user.click(sortButton);
+    expect(firstNameHeader).toHaveAttribute('aria-sort', 'descending');
+    expect(
+      within(firstNameHeader).getByText(
+        `${TABLE_COLUMN_LABELS.FIRST_NAME} ${TABLE_A11Y_COPY.SORT_DESC_SUFFIX.trim()}`,
+      ),
+    ).toBeInTheDocument();
+    const descValues = readFirstColumn();
+    expect(descValues[0]).toBe(expectedDesc[0].firstName);
+  });
+
+  it('resets to page 1 after sorting a new column and windows pagination buttons', async () => {
+    const rows = createRows();
+    const user = userEvent.setup();
+    render(<CustomTable rows={rows} />);
+
+    const pagination = screen.getAllByLabelText<HTMLDivElement>(TABLE_A11Y_COPY.PAGINATION_ARIA_LABEL, {
+      selector: 'nav',
+    })[0];
+    const numberButtons = () =>
+      within(pagination)
+        .getAllByRole('button')
+        .filter((btn) => /^\d+$/.test(btn.textContent ?? ''))
+        .map((btn) => btn.textContent ?? '');
+
+    expect(numberButtons()).toEqual(['1', '2', '3', '4', '5']);
+
+    const pageButton = (label: string) => within(pagination).getAllByRole('button', { name: label })[0];
+
+    await user.click(pageButton('4'));
+    expect(pageButton('4')).toHaveAttribute('aria-current', 'page');
+    expect(numberButtons()).toEqual(['2', '3', '4', '5', '6']);
+
+    const lastNameHeader = screen.getAllByRole('columnheader')[1];
+    const lastNameButton = within(lastNameHeader).getByRole('button', {
+      name: `${TABLE_A11Y_COPY.SORT_BUTTON_PREFIX}${TABLE_COLUMN_LABELS.LAST_NAME}`,
+    });
+    await user.click(lastNameButton);
+
+    expect(pageButton('1')).toHaveAttribute('aria-current', 'page');
+    expect(numberButtons()).toEqual(['1', '2', '3', '4', '5']);
+  });
+
+  it('disables previous and next navigation at the bounds', async () => {
+    const rows = createRows();
+    const user = userEvent.setup();
+    render(<CustomTable rows={rows} />);
+
+    const pagination = screen.getAllByLabelText<HTMLDivElement>(TABLE_A11Y_COPY.PAGINATION_ARIA_LABEL, {
+      selector: 'nav',
+    })[0];
+    const prev = within(pagination).getAllByRole('button', { name: TABLE_A11Y_COPY.PREVIOUS_PAGE })[0];
+    const next = within(pagination).getAllByRole('button', { name: TABLE_A11Y_COPY.NEXT_PAGE })[0];
+    const pageButton = (label: string) => within(pagination).getAllByRole('button', { name: label })[0];
+
+    expect(prev).toBeDisabled();
+    expect(next).not.toBeDisabled();
+
+    await user.click(pageButton('4'));
+    await user.click(pageButton('6'));
+    await user.click(pageButton('8'));
+
+    expect(next).toBeDisabled();
+    expect(prev).not.toBeDisabled();
+  });
+});

--- a/src/hooks/__tests__/useMediaQuery.test.tsx
+++ b/src/hooks/__tests__/useMediaQuery.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import ReactDOMServer from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalMatchMedia = window.matchMedia;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  globalThis.window = originalWindow;
+  if (originalMatchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  }
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('useMediaQuery', () => {
+  it('returns false when rendering without a window (SSR)', async () => {
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+
+    const module = await import('../useMediaQuery');
+    const { useMediaQuery } = module;
+
+    function TestComponent() {
+      const matches = useMediaQuery('(max-width: 600px)');
+      return <span>{String(matches)}</span>;
+    }
+
+    const markup = ReactDOMServer.renderToString(<TestComponent />);
+    expect(markup).toContain('false');
+  });
+
+  it('reacts to matchMedia changes and cleans up listeners', async () => {
+    const module = await import('../useMediaQuery');
+    const { useMediaQuery } = module;
+
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+    const addEventListener = vi.fn(
+      (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.add(listener);
+      },
+    );
+    const removeEventListener = vi.fn(
+      (_event: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener);
+      },
+    );
+
+    const mql: MediaQueryList = {
+      media: '(max-width: 600px)',
+      matches: true,
+      onchange: null,
+      addEventListener,
+      removeEventListener,
+      addListener: addEventListener as unknown as MediaQueryList['addListener'],
+      removeListener: removeEventListener as unknown as MediaQueryList['removeListener'],
+      dispatchEvent: vi.fn(),
+    };
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => mql),
+    });
+
+    const { result, unmount } = renderHook(() => useMediaQuery('(max-width: 600px)'));
+
+    await waitFor(() => expect(addEventListener).toHaveBeenCalledTimes(1));
+    expect(result.current).toBe(true);
+
+    const emitChange = (matches: boolean) => {
+      mql.matches = matches;
+      listeners.forEach((listener) => listener({ matches } as MediaQueryListEvent));
+    };
+
+    act(() => emitChange(false));
+    expect(result.current).toBe(false);
+
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/usePagination.test.ts
+++ b/src/hooks/__tests__/usePagination.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { usePagination } from '@/hooks/usePagination';
+
+describe('usePagination', () => {
+  const items = Array.from({ length: 12 }, (_, i) => `item-${i + 1}`);
+
+  it('derives total pages, range, and sliced data', () => {
+    const { result } = renderHook(() => usePagination(items, 5));
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.pages).toBe(3);
+    expect(result.current.total).toBe(items.length);
+    expect(result.current.range).toEqual([1, 5]);
+    expect(result.current.data).toEqual(items.slice(0, 5));
+  });
+
+  it('clamps page updates within bounds', () => {
+    const { result } = renderHook(() => usePagination(items, 5));
+
+    act(() => result.current.setPage(0));
+    expect(result.current.page).toBe(1);
+
+    act(() => result.current.setPage(10));
+    expect(result.current.page).toBe(result.current.pages);
+
+    act(() => result.current.setPage(2));
+    expect(result.current.page).toBe(2);
+    expect(result.current.range).toEqual([6, 10]);
+    expect(result.current.data).toEqual(items.slice(5, 10));
+  });
+
+  it('recomputes pagination when page size changes', () => {
+    const { result } = renderHook(() => usePagination(items, 4));
+
+    act(() => result.current.setPerPage(3));
+    expect(result.current.perPage).toBe(3);
+    expect(result.current.pages).toBe(4);
+    expect(result.current.range).toEqual([1, 3]);
+    expect(result.current.data).toEqual(items.slice(0, 3));
+
+    act(() => result.current.setPage(4));
+    expect(result.current.range).toEqual([10, 12]);
+    expect(result.current.data).toEqual(items.slice(9, 12));
+  });
+});

--- a/src/pages/__tests__/ArticlePage.test.tsx
+++ b/src/pages/__tests__/ArticlePage.test.tsx
@@ -1,0 +1,113 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ArticlePage from '../Article';
+import { ARTICLE_PAGE_COPY } from '@/constants';
+import { useArticle } from '@/services/api';
+import type { Article } from '@/types';
+
+vi.mock('@/services/api', () => ({
+  useArticle: vi.fn(),
+}));
+
+const useArticleMock = vi.mocked(useArticle);
+let originalTitle: string;
+
+beforeEach(() => {
+  originalTitle = document.title;
+  vi.clearAllMocks();
+});
+
+describe('ArticlePage', () => {
+  it('renders a skeleton while loading', () => {
+    useArticleMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { container } = render(<ArticlePage />);
+    expect(container.querySelector('.ant-skeleton')).toBeInTheDocument();
+  });
+
+  it('shows an error alert when the query fails', () => {
+    useArticleMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Boom'),
+    } as never);
+
+    render(<ArticlePage />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(ARTICLE_PAGE_COPY.LOAD_ERROR);
+    expect(alert).toHaveTextContent('Boom');
+  });
+
+  it('renders the article content and updates the document title', async () => {
+    const article: Article = {
+      id: 'a-1',
+      boolean: false,
+      phone: '+372 555-0100',
+      date: 1_700_000_000,
+      tags: ['design', 'ux'],
+      sex: 'f',
+      firstname: 'Jane',
+      surname: 'Doe',
+      email: 'jane@example.com',
+      title: 'Great article',
+      intro: '<p>Intro content</p>',
+      body: '<p>Body content</p>',
+      personal_code: 123456,
+      image: {
+        large: 'large.jpg',
+        medium: 'medium.jpg',
+        small: 'small.jpg',
+        alt: 'Hero alt',
+        title: 'Hero caption',
+      },
+      images: [],
+    };
+
+    useArticleMock.mockReturnValue({
+      data: article,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    render(<ArticlePage />);
+
+    expect(screen.getByRole('heading', { level: 1, name: article.title })).toBeInTheDocument();
+    expect(screen.getByLabelText(ARTICLE_PAGE_COPY.INTRO_SECTION_ARIA_LABEL)).toHaveTextContent(
+      'Intro content',
+    );
+    expect(screen.getByRole('img', { name: 'Hero alt' })).toBeInTheDocument();
+    expect(screen.getByText('Hero caption')).toBeInTheDocument();
+    expect(screen.getByLabelText(ARTICLE_PAGE_COPY.BODY_SECTION_ARIA_LABEL)).toHaveTextContent(
+      'Body content',
+    );
+    expect(screen.getByText('design')).toBeInTheDocument();
+    expect(screen.getByText('ux')).toBeInTheDocument();
+
+    await waitFor(() => expect(document.title).toBe(article.title));
+  });
+
+  it('renders nothing when data is null', () => {
+    useArticleMock.mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { container } = render(<ArticlePage />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+afterEach(() => {
+  document.title = originalTitle;
+});

--- a/src/pages/__tests__/TablePage.test.tsx
+++ b/src/pages/__tests__/TablePage.test.tsx
@@ -1,0 +1,85 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TablePage from '../Table';
+import { TABLE_PAGE_COPY } from '@/constants';
+import { useTable } from '@/services/api';
+import CustomTable from '@/components/table/CustomTable';
+import type { Mock } from 'vitest';
+
+vi.mock('@/services/api', () => ({
+  useTable: vi.fn(),
+}));
+
+vi.mock('@/components/table/CustomTable', () => ({
+  __esModule: true,
+  default: vi.fn(() => <div data-testid="custom-table" />),
+}));
+
+const useTableMock = vi.mocked(useTable);
+const CustomTableMock = CustomTable as unknown as Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TablePage', () => {
+  it('renders a skeleton while loading', () => {
+    useTableMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { container } = render(<TablePage />);
+    expect(container.querySelector('.ant-skeleton')).toBeInTheDocument();
+  });
+
+  it('renders an error alert when the query fails', () => {
+    useTableMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Failed'),
+    } as never);
+
+    render(<TablePage />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(TABLE_PAGE_COPY.LOAD_ERROR);
+    expect(alert).toHaveTextContent('Failed');
+  });
+
+  it('renders the table with returned data', () => {
+    const rows = [
+      { firstName: 'Jane', lastName: 'Doe', sex: 'Naine', birthDate: 1, phone: '555' },
+    ];
+
+    useTableMock.mockReturnValue({
+      data: rows,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    render(<TablePage />);
+
+    expect(screen.getByRole('heading', { level: 1, name: TABLE_PAGE_COPY.TITLE })).toBeInTheDocument();
+    expect(CustomTableMock).toHaveBeenCalledWith({ rows }, undefined);
+    expect(screen.getByTestId('custom-table')).toBeInTheDocument();
+  });
+
+  it('passes an empty array to the table when data is missing', () => {
+    useTableMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    render(<TablePage />);
+
+    expect(CustomTableMock).toHaveBeenCalledWith({ rows: [] }, undefined);
+  });
+});

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(),
+}));
+
+import axios from 'axios';
+import { useQuery } from '@tanstack/react-query';
+import { API_ENDPOINTS, QUERY_KEYS, SEX_LABELS } from '@/constants';
+import type { Article, Row, TwnListItem } from '@/types';
+import * as Api from '../api';
+
+const mockedAxiosGet = vi.mocked(axios.get);
+const useQueryMock = vi.mocked(useQuery);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('api utilities', () => {
+  it('converts unix seconds to Date objects', () => {
+    const date = Api.unixToDate(123);
+    expect(date.getTime()).toBe(123_000);
+  });
+
+  it('maps API list items into table rows', async () => {
+    const listItem: TwnListItem = {
+      id: '1',
+      boolean: true,
+      phone: '+372 555-0100',
+      date: 1_700_000_000,
+      tags: ['tag'],
+      sex: 'm',
+      firstname: 'John',
+      surname: 'Doe',
+      email: 'john@example.com',
+      title: 'Title',
+      intro: '<p>Intro</p>',
+      body: '<p>Body</p>',
+      personal_code: 123,
+      image: { large: 'large.jpg', medium: 'medium.jpg', small: 'small.jpg', alt: 'alt', title: 'title' },
+      images: [],
+    };
+
+    mockedAxiosGet.mockResolvedValueOnce({ data: { list: [listItem] } });
+
+    const rows = await Api.getTable();
+
+    expect(mockedAxiosGet).toHaveBeenCalledWith(API_ENDPOINTS.LIST, { signal: undefined });
+    expect(rows).toEqual<Row[]>([
+      {
+        firstName: 'John',
+        lastName: 'Doe',
+        sex: SEX_LABELS.MALE,
+        birthDate: listItem.date,
+        phone: listItem.phone,
+      },
+    ]);
+  });
+
+  it('configures useTable query options', async () => {
+    useQueryMock.mockImplementation(() => ({}) as never);
+
+    Api.useTable();
+
+    expect(useQueryMock).toHaveBeenCalledTimes(1);
+    const options = useQueryMock.mock.calls[0][0];
+    expect(options.queryKey).toEqual(QUERY_KEYS.TABLE);
+    expect(options.retry).toBe(2);
+    expect(options.staleTime).toBe(60_000);
+
+    const signal = {} as AbortSignal;
+    mockedAxiosGet.mockResolvedValueOnce({ data: { list: [] } });
+    const result = await options.queryFn({ signal });
+    expect(result).toEqual([]);
+    expect(mockedAxiosGet).toHaveBeenCalledWith(API_ENDPOINTS.LIST, { signal });
+  });
+
+  it('configures useArticle query options', async () => {
+    useQueryMock.mockImplementation(() => ({}) as never);
+
+    Api.useArticle();
+
+    const options = useQueryMock.mock.calls.at(-1)?.[0];
+    expect(options).toBeDefined();
+    expect(options?.queryKey).toEqual(QUERY_KEYS.ARTICLE);
+    expect(options?.retry).toBe(2);
+    expect(options?.staleTime).toBeUndefined();
+
+    const signal = {} as AbortSignal;
+    mockedAxiosGet.mockResolvedValueOnce({ data: {} });
+    const result = await options?.queryFn({ signal });
+    expect(result).toEqual({});
+    expect(mockedAxiosGet).toHaveBeenCalledWith(API_ENDPOINTS.ARTICLE, { signal });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,4 +13,9 @@ export default defineConfig({
       },
     },
   },
+  test: {
+    environment: 'jsdom',
+    exclude: ['**/node_modules/**', '**/dist/**', 'src/__tests__/e2e/**'],
+    setupFiles: ['./vitest.setup.ts'],
+  },
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (!globalThis.ResizeObserver) {
+  // @ts-expect-error - provide minimal ResizeObserver polyfill for Ant Design components
+  globalThis.ResizeObserver = ResizeObserverMock;
+}
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- configure Vitest for jsdom with setup to polyfill matchMedia and ResizeObserver
- add hook, service, page, layout, and table unit tests covering state, accessibility, and interactions
- ensure Sidebar menu assertions use Ant Design markup-aware queries so the layout tests pass

## Testing
- npx vitest run