### PR TITLE
Fix e2e smoke test copy expectations

### DIFF
--- a/src/__tests__/e2e/smoke.spec.ts
+++ b/src/__tests__/e2e/smoke.spec.ts
@@ -1,12 +1,18 @@
 import { test, expect } from '@playwright/test';
+import {
+  ARTICLE_PAGE_IDS,
+  HOME_PAGE_COPY,
+  NAVIGATION_COPY,
+  TABLE_PAGE_COPY,
+} from '@/constants';
 
 test('navigates between routes', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Welcome' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: HOME_PAGE_COPY.TITLE })).toBeVisible();
 
-  await page.getByRole('link', { name: 'Article' }).click();
-  await expect(page.getByRole('heading', { name: /Article/i })).toBeVisible();
+  await page.getByRole('link', { name: NAVIGATION_COPY.ARTICLE }).click();
+  await expect(page.locator(`#${ARTICLE_PAGE_IDS.TITLE}`)).toBeVisible();
 
-  await page.getByRole('link', { name: 'Table' }).click();
-  await expect(page.getByRole('heading', { name: 'Table' })).toBeVisible();
+  await page.getByRole('link', { name: NAVIGATION_COPY.TABLE }).click();
+  await expect(page.getByRole('heading', { name: TABLE_PAGE_COPY.TITLE })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- update the smoke e2e test to assert against the localized copy used in the app
- assert the article page heading by its stable id so the test no longer relies on English text

## Testing
- npm run e2e *(fails: Playwright browsers could not be downloaded in the execution environment)*